### PR TITLE
support for new education endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The gateway will reroute the client to the specified service. For example `GET /
 
 ## Endpoints
 - `/users`
-- `/education`
-- `admins`
+- `/courses`
+- `/evaluations`
+- `/admins`
 
 ## Technologies
 

--- a/src/proxy/proxy.controller.ts
+++ b/src/proxy/proxy.controller.ts
@@ -28,7 +28,8 @@ import {
     ) {
       this.serviceMap = {
         users: process.env.USERS_URL ?? 'http://localhost:3001',
-        education: process.env.EDUCATION_URL ?? 'http://localhost:3002',
+        courses: process.env.EDUCATION_URL ?? 'http://localhost:3002',
+        evaluations: process.env.EDUCATION_URL ?? 'http://localhost:3002',
         admins: process.env.ADMINS_URL ?? 'http://localhost:3004',
       };
     }

--- a/test/mock-education.service.ts
+++ b/test/mock-education.service.ts
@@ -4,7 +4,11 @@ export function startMockEducationService(port: number) {
     const app = express();
     app.use(express.json());
 
-    app.get('/education/ping', (_req, res) => {
+    app.get('/courses/ping', (_req, res) => {
+        res.json({ message: 'Pong from education service' })
+    });
+
+    app.get('/evaluations/ping', (_req, res) => {
         res.json({ message: 'Pong from education service' })
     });
 

--- a/test/proxy.e2e-spec.ts
+++ b/test/proxy.e2e-spec.ts
@@ -73,9 +73,18 @@ describe('ProxyController (e2e)', () => {
         expect(res.body).toEqual({ message: 'Pong from users service' });
     });
 
-    it('GET /education/ping should proxy to education service', async () => {
+    it('GET /courses/ping should proxy to education service', async () => {
         const res = await request(app.getHttpServer())
-            .get('/education/ping')
+            .get('/courses/ping')
+            .set('Authorization', 'Bearer mock-token');
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ message: 'Pong from education service' });
+    });
+
+    it('GET /evaluations/ping should proxy to education service', async () => {
+        const res = await request(app.getHttpServer())
+            .get('/evaluations/ping')
             .set('Authorization', 'Bearer mock-token');
 
         expect(res.status).toBe(200);


### PR DESCRIPTION
Adds support for the new endpoints for the education service:
- `/courses`
- `/evaluations`