### PR TITLE
Rule notification

### DIFF
--- a/src/controllers/gateway.controller.ts
+++ b/src/controllers/gateway.controller.ts
@@ -60,7 +60,7 @@ export class GatewayController {
     return res.data;
   }
 
-  async fetchUsers(): Promise<Object> {
+  async fetchUsers(): Promise<any> {
     logger.log(`Fetching users`);
     const url = `${this.serviceMap['users']}/users`;
 

--- a/src/controllers/gateway.controller.ts
+++ b/src/controllers/gateway.controller.ts
@@ -69,11 +69,11 @@ export class GatewayController {
       res = await firstValueFrom(this.http.get(url));
     } catch (e) {
       logger.warn(`Couldn't reach users service: ${e}`);
-      throw new HttpException(e.reponse, e.status);
+      throw new HttpException(e.response, e.status);
     }
 
     if (res.data?.error) {
-      throw new HttpException(`Failed to fecth users: ${res.data.error}`, 500);
+      throw new HttpException(`Failed to fetch users: ${res.data.error}`, 500);
     }
 
     return res.data;

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -67,6 +67,27 @@ export class EmailService {
       throw new HttpException(`Error sending assistant assignment email: ${err}`, 500)
     }
   }
+
+  async sendNewRulesEmail(
+    toName: string,
+    toEmail: string,
+    rules: any[],
+  ) {
+    const body = "";
+    const templateParams = {
+      to_name: toName,
+      to_email: toEmail,
+      body: body,
+    }
+
+    try {
+      const result = await emailjs.send(SERVICE_ID, TEMPLATE_ASSISTANT_ID, templateParams, KEYS);
+      logger.log('✅ New rules email sent:', result.status);
+    } catch (err) {
+      logger.error('❌ Error sending new rules email:', err);
+      throw new HttpException(`Error sending new rules email: ${err}`, 500);
+    }
+  }
 }
 
 const logger = new Logger(EmailService.name);

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -1,15 +1,120 @@
 import emailjs from '@emailjs/nodejs';
 import { HttpException, Injectable, Logger } from '@nestjs/common';
 
-const SERVICE_ID = 'service_7c9h1g8';
-const TEMPLATE_ENROLLMENT_ID = 'template_warjsk8';
-const TEMPLATE_ASSISTANT_ID = 'template_tnztalm';
-const PUBLIC_KEY = 'hKz0YVFI0a8LaRhc7'
-const KEYS = { privateKey: process.env.EMAIL_PRIVATE_KEY, publicKey: PUBLIC_KEY };
+export const SERVICE_ID = 'service_7c9h1g8';
+export const TEMPLATE_EMAIL_ID = 'template_tnztalm';
+export const PUBLIC_KEY = 'hKz0YVFI0a8LaRhc7'
+export const KEYS = { privateKey: process.env.EMAIL_PRIVATE_KEY, publicKey: PUBLIC_KEY };
 
 @Injectable()
 export class EmailService {
   constructor() { }
+
+  /**
+   * Generates the HTML content for the enrollment confirmation email.
+   *
+   * @param courseName - The name of the course the user is enrolled in.
+   * @returns The HTML string content of the email.
+   */
+  enrollmentTemplate(courseName: string): string {
+    return `
+      <div style="font-family: Arial, sans-serif; line-height: 1.5;">
+        <p>You have been successfully enrolled in the course <strong>"${courseName}"</strong>.</p>
+        <p>We wish you a productive and enriching learning experience.</p>
+      </div>
+    `;
+  }
+
+  /**
+   * Generates the HTML content for the teaching assistant assignment email.
+   *
+   * @param courseName - The name of the course for which the assignment is made.
+   * @param professorName - The name of the professor assigning the assistant.
+   * @returns The HTML string content of the email.
+   */
+  assistantAssignmentTemplate(courseName: string, professorName: string): string {
+    return `
+    <div style="font-family: Arial, sans-serif; line-height: 1.5;">
+      <p>You have been assigned as a <strong>teaching assistant</strong> for the course 
+      <strong>"${courseName}"</strong> by Professor <strong>${professorName}</strong>.</p>
+      <p>Thank you for your support and collaboration. We look forward to the positive impact you'll make.</p>
+    </div>
+  `;
+  }
+
+
+  /**
+   * Generates the HTML content for the "New Rules and Policies" email.
+   *
+   * @param rules                        - An array of rule objects, each containing:
+   *   - title: string                   - The title of the rule.
+   *   - description: string             - The detailed description of the rule.
+   *   - effective_date: string          - The date when the rule becomes effective.
+   *   - applicable_conditions: string[] - List of conditions under which the rule applies.
+   * 
+   * @returns The HTML string content of the email listing all the updated rules.
+   */
+  newRulesTemplate(rules: any[]): string {
+    const ruleStrings: string[] = [];
+    for (let i = 0; i < rules.length; i++) {
+      const title: string = rules[i].title;
+      const description: string = rules[i].description;
+      const effectiveDate: string = rules[i].effective_date;
+      const applicableConditions: string[] = rules[i].applicable_conditions;
+
+      const conditionsList = applicableConditions.map(condition =>
+        `<li>${condition}</li>`
+      ).join("");
+
+      const ruleHtml = `
+        <li style="margin-bottom: 1em;">
+          <strong>${title}</strong> <em>(${effectiveDate})</em><br />
+          <p>${description}</p>
+          <p><strong>This rule applies under the following conditions:</strong></p>
+          <ul>
+            ${conditionsList}
+          </ul>
+        </li>
+      `;
+
+      ruleStrings.push(ruleHtml);
+    }
+
+    return `
+    <div style="font-family: Arial, sans-serif; line-height: 1.5;">
+      <p>The rules and policies of the site have changed. Below are the updated rules:</p>
+      <ul>
+        ${ruleStrings.join("\n")}
+      </ul>
+    </div>`;
+  }
+
+  /**
+    * Sends an email with the given data.
+    *
+    * @param toName  - The name of the user to receive the email.
+    * @param toEmail - The name of the professor of the course.
+    * @param subject - The subject of the email.
+    * @param body    - The main text of the email.
+    *
+    * @throws {HttpException} - If there was an error with the email broker.
+    */
+  private async sendEmail(toName: string, toEmail: string, subject: string, body: string) {
+    const templateParams = {
+      toName,
+      toEmail,
+      subject,
+      body,
+    };
+
+    try {
+      const result = await emailjs.send(SERVICE_ID, TEMPLATE_EMAIL_ID, templateParams, KEYS);
+      logger.log(`✅ Email with subject ${subject} sent:`, result.status);
+    } catch (err) {
+      logger.error(`❌ Error sending email with subject "${subject}":`, err);
+      throw new HttpException(`Error sending email with subject "${subject}": ${err}`, 500)
+    }
+  }
 
   /**
     * Sends an enrollment email with the given data.
@@ -21,19 +126,9 @@ export class EmailService {
     * @throws {HttpException} - If there was an error with the email broker.
     */
   async sendEnrollmentEmail(toName: string, courseName: string, studentEmail: string) {
-    const templateParams = {
-      to_name: toName,
-      course_name: courseName,
-      student_email: studentEmail
-    };
-
-    try {
-      const result = await emailjs.send(SERVICE_ID, TEMPLATE_ENROLLMENT_ID, templateParams, KEYS);
-      logger.log('✅ Enrollment email sent:', result.status);
-    } catch (err) {
-      logger.error('❌ Error sending enrollment email:', err);
-      throw new HttpException(`Error sending enrollment email: ${err}`, 500)
-    }
+    const subject = `Enrollment Confirmation - ${courseName}`;
+    const body = this.enrollmentTemplate(courseName);
+    await this.sendEmail(toName, studentEmail, subject, body);
   }
 
   /**
@@ -52,41 +147,28 @@ export class EmailService {
     courseName: string,
     studentEmail: string
   ) {
-    const templateParams = {
-      to_name: toName,
-      professor_name: professorName,
-      course_name: courseName,
-      student_email: studentEmail
-    };
-
-    try {
-      const result = await emailjs.send(SERVICE_ID, TEMPLATE_ASSISTANT_ID, templateParams, KEYS);
-      logger.log('✅ Assistant assignment email sent:', result.status);
-    } catch (err) {
-      logger.error('❌ Error sending assistant assignment email:', err);
-      throw new HttpException(`Error sending assistant assignment email: ${err}`, 500)
-    }
+    const subject = `Assistant Assignment - ${courseName}`;
+    const body = this.assistantAssignmentTemplate(courseName, professorName);
+    await this.sendEmail(toName, studentEmail, subject, body);
   }
 
+  /**
+    * Sends a new rules and policies email with the given data.
+    *
+    * @param toName  - The name of the user to receive the email.
+    * @param toEmail - The name of the professor of the course.
+    * @param rules   - The new rules and policies.
+    *
+    * @throws {HttpException} - If there was an error with the email broker.
+    */
   async sendNewRulesEmail(
     toName: string,
     toEmail: string,
     rules: any[],
   ) {
-    const body = "";
-    const templateParams = {
-      to_name: toName,
-      to_email: toEmail,
-      body: body,
-    }
-
-    try {
-      const result = await emailjs.send(SERVICE_ID, TEMPLATE_ASSISTANT_ID, templateParams, KEYS);
-      logger.log('✅ New rules email sent:', result.status);
-    } catch (err) {
-      logger.error('❌ Error sending new rules email:', err);
-      throw new HttpException(`Error sending new rules email: ${err}`, 500);
-    }
+    const subject = "New Rules and Policies";
+    const body = this.newRulesTemplate(rules);
+    await this.sendEmail(toName, toEmail, subject, body);
   }
 }
 

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -72,7 +72,7 @@ export class NotificationService {
     */
   async sendEnrollmentEmail(user: any, toName: string, courseName: string, studentEmail: string, topic: string) {
     this.validateUserConfig(user, topic);
-    return await this.mail.sendEnrollmentEmail(toName, courseName, studentEmail);
+    await this.mail.sendEnrollmentEmail(toName, courseName, studentEmail);
   }
 
   /**
@@ -85,9 +85,22 @@ export class NotificationService {
     * @param studentEmail  - The email of the user.
     * @param topic         - The kind of notification they will receive.
     */
-    async sendAssistantAssignmentEmail(user: any, toName: string, professorName: string, courseName: string, studentEmail: string, topic: string) {
+  async sendAssistantAssignmentEmail(user: any, toName: string, professorName: string, courseName: string, studentEmail: string, topic: string) {
     this.validateUserConfig(user, topic);
-    return await this.mail.sendAssistantAssignmentEmail(toName, professorName, courseName, studentEmail);
+    await this.mail.sendAssistantAssignmentEmail(toName, professorName, courseName, studentEmail);
+  }
+
+  /**
+    * Sends rule modification emails to users.
+    *
+    * @param users - A list of users to send the emails.
+    * @param rules - A list of the new rules the admins have selected.
+    */
+  async sendNewRulesEmails(users: any[], rules: any[]) {
+    for (let i = 0; i < users.length; i++) {
+      const uuid = users[i].uuid
+      await this.mail.sendNewRulesEmail(uuid, rules);
+    }
   }
 }
 

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -98,8 +98,9 @@ export class NotificationService {
     */
   async sendNewRulesEmails(users: any[], rules: any[]) {
     for (let i = 0; i < users.length; i++) {
-      const uuid = users[i].uuid
-      await this.mail.sendNewRulesEmail(uuid, rules);
+      const name = users[i].name;
+      const email = users[i].email;
+      await this.mail.sendNewRulesEmail(name, email, rules);
     }
   }
 }

--- a/test/email.e2e-spec.ts
+++ b/test/email.e2e-spec.ts
@@ -14,6 +14,45 @@ describe('EmailService', () => {
     jest.clearAllMocks(); // clear mocks between tests
   });
 
+  describe('sendNewRulesEmail', () => {
+    const rules = [{
+      title: 'title',
+      description: 'description',
+      effective_date: '2025-05-05',
+      applicable_conditions: ["condition 1", "condition 2"]
+    }];
+
+    it('should call emailjs.send with correct parameters', async () => {
+      const mockResponse = { status: 200 };
+      (emailjs.send as jest.Mock).mockResolvedValue(mockResponse);
+
+      await service.sendNewRulesEmail('Thomas', 'thomas@example.com', rules)
+
+      expect(emailjs.send).toHaveBeenCalledWith(
+        SERVICE_ID,
+        TEMPLATE_EMAIL_ID,
+        {
+          toName: 'Thomas',
+          toEmail: 'thomas@example.com',
+          subject: 'New Rules and Policies',
+          body: service.newRulesTemplate(rules)
+        },
+        expect.objectContaining({
+          privateKey: process.env.EMAIL_PRIVATE_KEY,
+          publicKey: PUBLIC_KEY,
+        })
+      );
+    });
+
+    it('should throw HttpException if emailjs.send fails', async () => {
+      (emailjs.send as jest.Mock).mockRejectedValue(new Error('Failed'));
+
+      await expect(
+        service.sendNewRulesEmail('Alice', 'Math 101', rules)
+      ).rejects.toThrow(HttpException);
+    });
+  });
+
   describe('sendEnrollmentEmail', () => {
     it('should call emailjs.send with correct parameters', async () => {
       const mockResponse = { status: 200 };

--- a/test/email.e2e-spec.ts
+++ b/test/email.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { EmailService } from '../src/services/email.service';
+import { EmailService, TEMPLATE_EMAIL_ID, PUBLIC_KEY, SERVICE_ID, KEYS } from '../src/services/email.service';
 import { HttpException } from '@nestjs/common';
 import emailjs from '@emailjs/nodejs';
 
@@ -22,16 +22,17 @@ describe('EmailService', () => {
       await service.sendEnrollmentEmail('Alice', 'Math 101', 'alice@example.com');
 
       expect(emailjs.send).toHaveBeenCalledWith(
-        'service_7c9h1g8',
-        'template_warjsk8',
+        SERVICE_ID,
+        TEMPLATE_EMAIL_ID,
         {
-          to_name: 'Alice',
-          course_name: 'Math 101',
-          student_email: 'alice@example.com',
+          toName: 'Alice',
+          toEmail: 'alice@example.com',
+          subject: 'Enrollment Confirmation - Math 101',
+          body: service.enrollmentTemplate('Math 101'),
         },
         expect.objectContaining({
           privateKey: process.env.EMAIL_PRIVATE_KEY,
-          publicKey: 'hKz0YVFI0a8LaRhc7',
+          publicKey: PUBLIC_KEY,
         })
       );
     });
@@ -58,17 +59,17 @@ describe('EmailService', () => {
       );
 
       expect(emailjs.send).toHaveBeenCalledWith(
-        'service_7c9h1g8',
-        'template_tnztalm',
+        SERVICE_ID,
+        TEMPLATE_EMAIL_ID,
         {
-          to_name: 'Bob',
-          professor_name: 'Prof. Smith',
-          course_name: 'CS101',
-          student_email: 'bob@example.com',
+          toName: 'Bob',
+          toEmail: 'bob@example.com',
+          subject: 'Assistant Assignment - CS101',
+          body: service.assistantAssignmentTemplate('CS101', 'Prof. Smith')
         },
         expect.objectContaining({
           privateKey: process.env.EMAIL_PRIVATE_KEY,
-          publicKey: 'hKz0YVFI0a8LaRhc7',
+          publicKey: PUBLIC_KEY,
         })
       );
     });

--- a/test/email.e2e-spec.ts
+++ b/test/email.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('EmailService', () => {
       (emailjs.send as jest.Mock).mockRejectedValue(new Error('Failed'));
 
       await expect(
-        service.sendNewRulesEmail('Alice', 'Math 101', rules)
+        service.sendNewRulesEmail('Alice', 'alice@example.com', rules)
       ).rejects.toThrow(HttpException);
     });
   });

--- a/test/gateway.e2e-spec.ts
+++ b/test/gateway.e2e-spec.ts
@@ -213,7 +213,7 @@ describe('ProxyController (e2e)', () => {
         topic: 'general',
       });
 
-    expect(response.status).toBe(201); // or the default if you didn't set a status
+    expect(response.status).toBe(201);
     expect(notificationService.notifyUser).toHaveBeenCalledWith(
       expect.objectContaining({
         uid: 'test-uid',

--- a/test/notification.e2e-spec.ts
+++ b/test/notification.e2e-spec.ts
@@ -10,6 +10,8 @@ describe('NotificationService', () => {
 
   const mockUser = {
     uuid: 'user-123',
+    name: 'Bob',
+    email: 'bob@example.com',
     pushToken: 'ExponentPushToken[abc123]',
     pushTaskAssignment: true,
     pushMessageReceived: true,
@@ -26,6 +28,7 @@ describe('NotificationService', () => {
     emailService = {
       sendEnrollmentEmail: jest.fn(),
       sendAssistantAssignmentEmail: jest.fn(),
+      sendNewRulesEmail: jest.fn(),
     } as any;
 
     service = new NotificationService(pushService, emailService);
@@ -101,6 +104,25 @@ describe('NotificationService', () => {
       await expect(
         service.sendAssistantAssignmentEmail(user, 'Bob', 'Prof. John', 'History 101', 'bob@example.com', 'assistant-assignment'),
       ).rejects.toThrow(HttpException);
+    });
+  });
+
+
+  describe('sendNewRulesEmail', () => {
+    it('should send email', async () => {
+      const users = [mockUser];
+      const rules = [{
+        title: "title",
+        description: "description",
+        effective_date: "2025-05-05",
+        applicable_conditions: ["cond1", "cond2"]
+      }];
+      await service.sendNewRulesEmails(users, rules);
+      expect(emailService.sendNewRulesEmail).toHaveBeenCalledWith(
+        mockUser.name,
+        mockUser.email,
+        rules,
+      );
     });
   });
 });


### PR DESCRIPTION
Gateway changes to support a single emailjs template for multiple custom templates and the imlementation of a new template for the rules and policies user story

to send a rules and policies email use `POST /email/rules` passing in a `rules` field in the body as an array of Rule objects with `title:string`, `description:string`, `effective_date:string` and `applicable_conditions:string[]`